### PR TITLE
fix: broken tests in test suite

### DIFF
--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -52,7 +52,7 @@ describe('sendToCommitGuard', () => {
 
     expect(fetch).toHaveBeenCalledWith(
       'https://api.commitguard.ai/v1/analyze',
-      {
+      expect.objectContaining({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -64,7 +64,7 @@ describe('sendToCommitGuard', () => {
           eslint: mockEslint,
           config: mockConfig,
         }),
-      },
+      }),
     )
     expect(result).toEqual(mockResponse)
   })
@@ -157,7 +157,7 @@ describe('bypassCommitGuard', () => {
     expect(git.getLastDiff).toHaveBeenCalled()
     expect(fetch).toHaveBeenCalledWith(
       'https://api.commitguard.ai/v1/bypass',
-      {
+      expect.objectContaining({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -167,7 +167,7 @@ describe('bypassCommitGuard', () => {
         body: JSON.stringify({
           diff: 'diff content',
         }),
-      },
+      }),
     )
     expect(result).toEqual(mockBypassResponse)
   })

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -193,7 +193,11 @@ describe('manageConfig', () => {
     vi.resetModules()
     vi.mocked(os.homedir).mockReturnValue(mockHomedir)
     vi.mocked(childProcess.execFileSync).mockReturnValue(mockProjectId)
-    vi.mocked(fs.existsSync).mockReturnValue(false)
+    vi.mocked(fs.existsSync).mockImplementation((path) => {
+      if (typeof path === 'string' && path.includes('.git'))
+        return true
+      return false
+    })
   })
 
   afterEach(() => {
@@ -201,12 +205,14 @@ describe('manageConfig', () => {
   })
 
   it('should save new configuration when user confirms', async () => {
+    vi.mocked(fs.existsSync).mockImplementation((path) => {
+      return typeof path === 'string' && path.includes('.git')
+    })
     vi.mocked(clack.intro).mockReturnValue(undefined)
     vi.mocked(clack.multiselect).mockResolvedValue(['security', 'performance'])
     vi.mocked(clack.isCancel).mockReturnValue(false)
     vi.mocked(clack.confirm).mockResolvedValue(true)
     vi.mocked(clack.outro).mockReturnValue(undefined)
-    vi.mocked(fs.existsSync).mockReturnValue(false)
     const { manageConfig } = await import('./config')
 
     await manageConfig()
@@ -279,7 +285,11 @@ describe('manageConfig', () => {
       customRule: '',
     }
 
-    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.existsSync).mockImplementation((path) => {
+      if (typeof path === 'string' && (path.includes('.git') || path.includes('projects.json')))
+        return true
+      return false
+    })
     vi.mocked(fs.readFileSync).mockReturnValue(
       JSON.stringify({ [mockProjectId]: existingConfig }),
     )
@@ -316,7 +326,11 @@ describe('manageConfig', () => {
       customRule: '',
     }
 
-    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.existsSync).mockImplementation((path) => {
+      if (typeof path === 'string' && (path.includes('.git') || path.includes('projects.json')))
+        return true
+      return false
+    })
     vi.mocked(fs.readFileSync).mockReturnValue(
       JSON.stringify({ [mockProjectId]: existingConfig }),
     )
@@ -354,11 +368,14 @@ describe('manageConfig', () => {
   })
 
   it('should create config directory if it does not exist', async () => {
+    vi.mocked(fs.existsSync).mockImplementation((path) => {
+      // .git exists, but config dir (implicitly checked) does not
+      return typeof path === 'string' && path.includes('.git')
+    })
     vi.mocked(clack.intro).mockReturnValue(undefined)
     vi.mocked(clack.multiselect).mockResolvedValue(['performance'])
     vi.mocked(clack.isCancel).mockReturnValue(false)
     vi.mocked(clack.confirm).mockResolvedValue(true)
-    vi.mocked(fs.existsSync).mockReturnValue(false)
     vi.mocked(clack.outro).mockReturnValue(undefined)
     const { manageConfig } = await import('./config')
 

--- a/src/utils/staged.test.ts
+++ b/src/utils/staged.test.ts
@@ -19,6 +19,7 @@ vi.mock('consola', () => ({
     success: vi.fn(),
     log: vi.fn(),
     prompt: vi.fn(),
+    box: vi.fn(),
   },
 }))
 vi.mock('string-width', () => ({
@@ -144,6 +145,8 @@ describe('onStaged', () => {
 
   it('should handle analysis errors gracefully', async () => {
     clearCache()
+    const originalIsTTY = process.stdout.isTTY
+    process.stdout.isTTY = true
 
     const mockDiff = 'diff content'
     const mockHash = 'abc123'
@@ -160,10 +163,9 @@ describe('onStaged', () => {
     expect(consola.box).toHaveBeenCalledWith({
       title: 'Analysis Failed',
       message: 'API error',
-      style: {
-        borderColor: 'red',
-      },
     })
+
+    process.stdout.isTTY = originalIsTTY
   })
 })
 

--- a/src/utils/staged.ts
+++ b/src/utils/staged.ts
@@ -10,7 +10,6 @@ import { getStagedDiff } from './git'
 import { createDiffHash } from './global'
 
 const CACHE_PATH = join('.git', 'commitguard-cache.json')
-const config = loadConfig()
 
 interface CacheData {
   hash: string
@@ -116,6 +115,7 @@ export async function onStaged() {
   }
 
   try {
+    const config = loadConfig()
     const eslint = await getEslintRules()
     const response = await sendToCommitGuard(diff, eslint.rules, config)
 


### PR DESCRIPTION
# PR: Fix - Broken Tests

## Description
This PR resolves 11 failing tests in the test suite affecting `api.test.ts`, `config.test.ts`, and `staged.test.ts`.

## Changes
- **`src/utils/api.test.ts`**: Updated `fetch` mock expectations to account for `AbortSignal` (using `expect.objectContaining`).
- **`src/utils/config.test.ts`**: Explicitly mocked `fs.existsSync` to return `true` for `.git` directory checks, fixing "No .git folder found" errors in tests.
- **`src/utils/staged.ts`**: Refactored `onStaged` to lazy-load configuration. This fixes a race condition in tests where the mock configuration wasn't applied because the module-level `loadConfig()` executed before the mock was registered.
- **`src/utils/staged.test.ts`**:
    - Mocked `process.stdout.isTTY = true` to verify `consola.box` calls.
    - Updated `consola.box` expectation to match actual usage (removed `style` property).

## Verification
- All tests passing (`pnpm vitest run`).
